### PR TITLE
Cpp fix issue with authorize

### DIFF
--- a/cpp-qt/cortexclient/CortexClient.cpp
+++ b/cpp-qt/cortexclient/CortexClient.cpp
@@ -84,14 +84,14 @@ void CortexClient::requestAccess(QString clientId, QString clientSecret)
     sendRequest("requestAccess", params);
 }
 
-void CortexClient::authorize(QString clientId, QString clientSecret, QString license) {
+void CortexClient::authorize(QString clientId, QString clientSecret, QString license, int debit) {
     QJsonObject params;
     params["clientId"] = clientId;
     params["clientSecret"] = clientSecret;
     if (! license.isEmpty()) {
         params["license"] = license;
-        params["debit"] = 1;
     }
+    params["debit"] = debit;
     sendRequest("authorize", params);
 }
 
@@ -245,7 +245,7 @@ void CortexClient::sendRequest(QString method, QJsonObject params) {
 
     // send the json message
     QString message = QJsonDocument(request).toJson(QJsonDocument::Compact);
-    //qDebug() << " * send    " << message;
+    qDebug().noquote() << " * send    " << message;
     socket.sendTextMessage(message);
 
     // remember the method used for this request
@@ -254,8 +254,6 @@ void CortexClient::sendRequest(QString method, QJsonObject params) {
 }
 
 void CortexClient::onMessageReceived(QString message) {
-    //qDebug() << " * received" << message;
-
     // parse the json message
     QJsonParseError err;
     QJsonDocument doc = QJsonDocument::fromJson(message.toUtf8(), &err);
@@ -269,6 +267,8 @@ void CortexClient::onMessageReceived(QString message) {
     QString sid = response.value("sid").toString();
 
     if (id != -1) {
+        qDebug().noquote() << " * received" << message;
+
         // this is a RPC response, we get the method from the id
         // we must know the method in order to understand the result
         QString method = methodForRequestId.value(id);
@@ -289,6 +289,7 @@ void CortexClient::onMessageReceived(QString message) {
         double time = response.value("time").toDouble();
         QJsonArray data;
         QString stream;
+        //qDebug().noquote() << " * STEAM" << message;
 
         // find the data field inside the response
         for (auto it = response.begin(); it != response.end(); ++it) {

--- a/cpp-qt/cortexclient/CortexClient.cpp
+++ b/cpp-qt/cortexclient/CortexClient.cpp
@@ -212,6 +212,14 @@ void CortexClient::stopRecord(QString token, QString sessionId)
     sendRequest("stopRecord", params);
 }
 
+void CortexClient::getRecordInfos(QString token, QString recordId)
+{
+    QJsonObject params;
+    params["cortexToken"] = token;
+    params["recordIds"] = QJsonArray{recordId};
+    sendRequest("getRecordInfos", params);
+}
+
 void CortexClient::injectMarker(QString token, QString sessionId,
                                 QString label, int value, qint64 time) {
     QJsonObject params;
@@ -395,6 +403,10 @@ void CortexClient::handleResponse(QString method, const QJsonValue &result) {
     else if (method == "stopRecord") {
         QJsonObject record = result.toObject().value("record").toObject();
         emit stopRecordOk(record["uuid"].toString());
+    }
+    else if (method == "getRecordInfos") {
+        QJsonObject record = result.toArray().at(0).toObject();
+        emit getRecordInfosOk(record);
     }
     else if (method == "injectMarker") {
         QJsonObject marker = result.toObject().value("marker").toObject();

--- a/cpp-qt/cortexclient/CortexClient.h
+++ b/cpp-qt/cortexclient/CortexClient.h
@@ -74,6 +74,7 @@ public slots:
 
     void createRecord(QString token, QString sessionId, QString title);
     void stopRecord(QString token, QString sessionId);
+    void getRecordInfos(QString token, QString recordId);
 
     // insert a marker, to mark an event in a session
     // you can use injectMarker alone, to mark an instant event
@@ -105,6 +106,7 @@ signals:
     void trainingOk(QString msg);
     void createRecordOk(QString recordId);
     void stopRecordOk(QString recordId);
+    void getRecordInfosOk(QJsonObject record);
     void injectMarkerOk(QString markerId);
     void updateMarkerOk();
 

--- a/cpp-qt/cortexclient/CortexClient.h
+++ b/cpp-qt/cortexclient/CortexClient.h
@@ -48,7 +48,7 @@ public slots:
     void requestAccess(QString clientId, QString clientSecret);
 
     // get an authorization token
-    void authorize(QString clientId, QString clientSecret, QString license);
+    void authorize(QString clientId, QString clientSecret, QString license, int debit);
 
     void controlDevice(QString headsetId, QString command, QJsonObject flexMapping);
 

--- a/cpp-qt/cortexclient/SessionCreator.cpp
+++ b/cpp-qt/cortexclient/SessionCreator.cpp
@@ -51,7 +51,7 @@ void SessionCreator::createSession(CortexClient* client,
 
 void SessionCreator::onGetUserLoginOk(QString emotivId) {
     if (emotivId.isEmpty()) {
-        qInfo() << "First, you must login with Cortex App";
+        qInfo() << "First, you must login with EMOTIV App";
         QCoreApplication::quit();
         return;
     }
@@ -61,8 +61,10 @@ void SessionCreator::onGetUserLoginOk(QString emotivId) {
 
 void SessionCreator::onRequestAccessOk(bool accessGranted, QString message) {
     if (accessGranted) {
-        qInfo() << "This application was authorized in CortexApp";
-        client->authorize(ClientId, ClientSecret, license);
+        qInfo() << "This application was authorized in EMOTIV App";
+        // if we want to activate the session, then we need to debit the license
+        int debit = activate ? 1 : 0;
+        client->authorize(ClientId, ClientSecret, license, debit);
     }
     else {
         qInfo() << message;

--- a/cpp-qt/marker/Marker.cpp
+++ b/cpp-qt/marker/Marker.cpp
@@ -27,6 +27,7 @@ Marker::Marker(QObject *parent) : QObject(parent) {
     connect(&client, &CortexClient::closeSessionOk, this, &Marker::onCloseSessionOK);
     connect(&client, &CortexClient::injectMarkerOk, this, &Marker::onInjectMarkerOK);
     connect(&client, &CortexClient::updateMarkerOk, this, &Marker::onUpdateMarkerOK);
+    connect(&client, &CortexClient::getRecordInfosOk, this, &Marker::onGetRecordInfosOk);
 
     connect(&finder, &HeadsetFinder::headsetFound, this, &Marker::onHeadsetFound);
     connect(&creator, &SessionCreator::sessionCreated, this, &Marker::onSessionCreated);
@@ -118,5 +119,11 @@ void Marker::closeSession() {
 }
 
 void Marker::onCloseSessionOK() {
+    client.getRecordInfos(token, recordId);
+}
+
+void Marker::onGetRecordInfosOk(QJsonObject record)
+{
+    qDebug().noquote() << "The record:" << record;
     client.close();
 }

--- a/cpp-qt/marker/Marker.cpp
+++ b/cpp-qt/marker/Marker.cpp
@@ -23,6 +23,7 @@ Marker::Marker(QObject *parent) : QObject(parent) {
     connect(&client, &CortexClient::disconnected, this, &Marker::onDisconnected);
     connect(&client, &CortexClient::errorReceived, this, &Marker::onErrorReceived);
     connect(&client, &CortexClient::createRecordOk, this, &Marker::onRecordCreated);
+    connect(&client, &CortexClient::stopRecordOk, this, &Marker::closeSession);
     connect(&client, &CortexClient::closeSessionOk, this, &Marker::onCloseSessionOK);
     connect(&client, &CortexClient::injectMarkerOk, this, &Marker::onInjectMarkerOK);
     connect(&client, &CortexClient::updateMarkerOk, this, &Marker::onUpdateMarkerOK);
@@ -64,6 +65,7 @@ void Marker::onSessionCreated(QString token, QString sessionId) {
 void Marker::onRecordCreated(QString recordId)
 {
     qInfo() << "Record created, id" << recordId;
+    this->recordId = recordId;
 
     // after a few seconds, inject some markers
     QTimer::singleShot(5*1000, this, &Marker::injectMarker1);
@@ -71,7 +73,7 @@ void Marker::onRecordCreated(QString recordId)
     QTimer::singleShot(21*1000, this, &Marker::injectStopMarker2);
 
     // close the session after 30 seconds
-    QTimer::singleShot(30*1000, this, &Marker::closeSession);
+    QTimer::singleShot(30*1000, this, &Marker::stopRecord);
 }
 
 void Marker::injectMarker1() {
@@ -102,6 +104,12 @@ void Marker::onInjectMarkerOK(QString markerId) {
 void Marker::onUpdateMarkerOK()
 {
     qInfo() << "Update marker OK";
+}
+
+void Marker::stopRecord()
+{
+    qInfo() << "Stopping the record";
+    client.stopRecord(token, sessionId);
 }
 
 void Marker::closeSession() {

--- a/cpp-qt/marker/Marker.h
+++ b/cpp-qt/marker/Marker.h
@@ -51,6 +51,7 @@ private slots:
     void stopRecord();
     void closeSession();
     void onCloseSessionOK();
+    void onGetRecordInfosOk(QJsonObject record);
 
 private:
     CortexClient client;

--- a/cpp-qt/marker/Marker.h
+++ b/cpp-qt/marker/Marker.h
@@ -48,6 +48,7 @@ private slots:
     void onInjectMarkerOK(QString markerId);
     void onUpdateMarkerOK();
 
+    void stopRecord();
     void closeSession();
     void onCloseSessionOK();
 


### PR DESCRIPTION
Fix a bug with the debit parameter of the authorize method.
Call queryRecords at the end of the marker example.